### PR TITLE
CircleTDR: Set TdrLevel as a Dword (integer), not string

### DIFF
--- a/DSCResources/CircleTDR/CircleTDR.schema.psm1
+++ b/DSCResources/CircleTDR/CircleTDR.schema.psm1
@@ -3,6 +3,7 @@ Configuration CircleTDR {
         Ensure = "Present"
         Key = "HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\GraphicsDrivers"
         ValueName = "TdrLevel"
+        ValueType = "Dword"
         ValueData = "0"
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

TdrLevel is now set as a "dword" (32-bit integer) rather than (implicitly) a string.