### PR TITLE
CircleMicrosoftTools: Forcing .NET Framework 3.5 to be installed

### DIFF
--- a/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
+++ b/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
@@ -141,6 +141,20 @@ Configuration CircleMicrosoftTools {
         Name = 'nuget.commandline'
     }
 
+    # This is not under $InstallDotNet as it does not require the machine to restart
+    # Which means it can be tested
+    Script InstallDotNet35
+    {
+        SetScript = {
+            Install-WindowsFeature Net-Framework-Core
+        }
+        TestScript = { 
+            $state = [scriptblock]::Create($GetScript).Invoke()
+            return (($state.Result.Lenght > 0) -And ($state.Result[0].Name == "Net-Framework-Core") -And ($state.Result[0].InstallState == "Installed") )
+         }
+        GetScript = { @{ Result = $(Get-WindowsFeature -Name Net-Framework-Core) } }
+    }
+
     if ($InstallDotNet) {
         # These are last. This is becuase despite my best efforts
         # They inspire the machine to require a reboot

--- a/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
+++ b/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
@@ -150,7 +150,8 @@ Configuration CircleMicrosoftTools {
         }
         TestScript = { 
             $state = [scriptblock]::Create($GetScript).Invoke()
-            return (($state.Result.Lenght > 0) -And ($state.Result[0].Name == "Net-Framework-Core") -And ($state.Result[0].InstallState == "Installed") )
+            Write-Verbose -Message $state.Resul
+            return (($state.Result.Lenght -gt 0) -And ($state.Result[0].Name -eq "Net-Framework-Core") -And ($state.Result[0].InstallState -eq "Installed") )
          }
         GetScript = { @{ Result = $(Get-WindowsFeature -Name Net-Framework-Core) } }
     }

--- a/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
+++ b/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
@@ -150,8 +150,13 @@ Configuration CircleMicrosoftTools {
         }
         TestScript = { 
             $state = [scriptblock]::Create($GetScript).Invoke()
-            Write-Verbose -Message $state.Resul
-            return (($state.Result.Lenght -gt 0) -And ($state.Result[0].Name -eq "Net-Framework-Core") -And ($state.Result[0].InstallState -eq "Installed") )
+
+            if ($state.Result.Lenght -lt 0){
+                Write-Verbose -Message "Net-Framework-Core not found"
+                return $false
+            }
+            Write-Verbose -Message ("Net-Framework-Core {0}" -f $state.Result[0].InstallState)
+            return (($state.Result[0].Name -eq "Net-Framework-Core") -And ($state.Result[0].InstallState -eq "Installed") )
          }
         GetScript = { @{ Result = $(Get-WindowsFeature -Name Net-Framework-Core) } }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
.NET Framework 3.5 is not being installed in the new images. This should force it to be installed.

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing
      Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
