### PR TITLE
Install Sysinternals to install PsExec as a dependency of build agent

### DIFF
--- a/DSCResources/CircleBuildAgentPreReq/CircleBuildAgentPreReq.schema.psm1
+++ b/DSCResources/CircleBuildAgentPreReq/CircleBuildAgentPreReq.schema.psm1
@@ -16,7 +16,9 @@ Configuration CircleBuildAgentPreReq {
         Name      = @(
             "git-lfs"
             "7zip.portable"
-            "gzip")
+            "gzip"
+            "sysinternals"
+        )
         DependsOn = "[cChocoPackageInstaller]installGit"
     }
 }

--- a/DSCResources/CircleNode/CircleNode.schema.psm1
+++ b/DSCResources/CircleNode/CircleNode.schema.psm1
@@ -86,7 +86,7 @@ Configuration CircleNode {
                 Write-Verbose "setting $using:Version as Default version"
                 & nvm use $using:Version
                 & nvm on
-                & "C:\ProgramData\nvm\v$using:Version\npm.cmd" install -g yarn
+                & "C:\ProgramData\nvm\v$using:Version\npm.cmd" install --scripts-prepend-node-path true -g yarn
             }
         }
         DependsOn  = '[CirclePath]nvm-symlink-path'

--- a/Tests/Integration/CircleBuildAgentPreReq.Integration.Tests.ps1
+++ b/Tests/Integration/CircleBuildAgentPreReq.Integration.Tests.ps1
@@ -91,6 +91,9 @@ try
             It "Has gzip on the path" {
                 (Get-Command -Name 'gzip') | Should -HaveCount 1
             }
+            It "Has PsExec on the path" {
+                (Get-Command -Name 'PsExec64.exe') | Should -HaveCount 1
+            }
         }
     }
     #endregion

--- a/Tests/Integration/CircleBuildAgentPreReq.config.ps1
+++ b/Tests/Integration/CircleBuildAgentPreReq.config.ps1
@@ -8,7 +8,7 @@ $ConfigurationData = @{
 }
 <#
     .SYNOPSIS
-    install git, 7zip, gzip and git-lfs. The needed tools for build agetn
+    install PsExec, git, 7zip, gzip and git-lfs. The needed tools for build agent
 #>
 Configuration CircleBuildAgentPreReq_Integration_Config
 {
@@ -17,8 +17,6 @@ Configuration CircleBuildAgentPreReq_Integration_Config
     Import-DscResource -ModuleName 'PackageManagement' -ModuleVersion '1.0.0.1'
     Import-DscResource -ModuleName 'ComputerManagementDsc'
     Import-DscResource -ModuleName 'cChoco'
-
-
 
     node $AllNodes.NodeName
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Install Sysinternals to install PsExec as a prerequisite for build agent

#### This Pull Request (PR) fixes the following issues
This PR itself does not fix or break things.
This will just update the tool set so that Windows VM images for CircleCI will contain Sysinternals, including PsExec, that is likely to be used by build agent in the future.

#### Task list

- [NA] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [NA] Resource documentation added/updated in README.md.
- [NA] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [NA] Comment-based help added/updated.
- [NA] Localization strings added/updated in all localization files as appropriate.
- [NA] Examples appropriately added/updated.
- [NA] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing
      Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
