### PR TITLE
Switch to webpi package due to webpicmd package being broken

### DIFF
--- a/DSCResources/CircleCloudTools/CircleCloudTools.schema.psm1
+++ b/DSCResources/CircleCloudTools/CircleCloudTools.schema.psm1
@@ -20,7 +20,8 @@ Configuration CircleCloudTools {
 
     cChocoPackageInstaller webpicmd
     {
-        Name      = "webpicmd"
+        Name      = "webpi"
+        Version   = "5.1"
         DependsOn = "[CircleChoco]choco"
     }
 


### PR DESCRIPTION
`choco install webpicmd` is failing with the below output. We can see that the `http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi` download link returns a 404.

This change makes the switch to use the `webpi` chocolatey package instead.
 
```
1621494245,,ui,message,    googlecompute:  Install command: 'choco install webpicmd -y --no-progress'
1621494259,,ui,message,    googlecompute: VERBOSE: [PACKER-60A6063F]:                            [[cChocoPackageInstaller]webpicmd::[CircleCloudTools]cloudTools]
1621494259,,ui,message,    googlecompute:  Package output Chocolatey v0.10.15 Installing the following packages: webpicmd By installing you accept licenses for
1621494259,,ui,message,    googlecompute: the packages.  lessmsi v1.8.1 [Approved] lessmsi package files install completed. Performing other installation steps.
1621494259,,ui,message,    googlecompute: C:\ProgramData\chocolatey\lib\lessmsi\tools\AddWindowsExplorerShortcut.exe.ignore Extracting
1621494259,,ui,message,    googlecompute: C:\ProgramData\chocolatey\lib\lessmsi\tools\lessmsi-v1.8.1.zip to C:\ProgramData\chocolatey\lib\lessmsi\tools...
1621494259,,ui,message,    googlecompute: C:\ProgramData\chocolatey\lib\lessmsi\tools  ShimGen has successfully created a shim for lessmsi-gui.exe  ShimGen has
1621494259,,ui,message,    googlecompute: successfully created a shim for lessmsi.exe  The install of lessmsi was successful.   Software installed to
1621494259,,ui,message,    googlecompute: 'C:\ProgramData\chocolatey\lib\lessmsi\tools'  webpicmd v7.1.50430.20141001 [Approved] webpicmd package files install
1621494259,,ui,message,    googlecompute: completed. Performing other installation steps. Attempt to get headers for
1621494259,,ui,message,    googlecompute: http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi
1621494259,,ui,message,    googlecompute: failed.   The remote file either doesn't exist%!(PACKER_COMMA) is unauthorized%!(PACKER_COMMA) or is forbidden for url
1621494259,,ui,message,    googlecompute: 'http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi
1621494259,,ui,message,    googlecompute: '. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
1621494259,,ui,message,    googlecompute: Downloading webpicmd 64 bit   from
1621494259,,ui,message,    googlecompute: 'http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi
1621494259,,ui,message,    googlecompute: ' WARNING: Write-ChocolateyFailure is deprecated and will be removed in v2. If you are the package maintainer%!(PACKER_COMMA) please
1621494259,,ui,message,    googlecompute: use 'throw $_.Exception' instead. ERROR: The remote file either doesn't exist%!(PACKER_COMMA) is unauthorized%!(PACKER_COMMA) or is forbidden for url
1621494259,,ui,message,    googlecompute:
1621494259,,ui,message,    googlecompute: 'http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi
1621494259,,ui,message,    googlecompute: '. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found." The
1621494259,,ui,message,    googlecompute: install of webpicmd was NOT successful. Error while running
1621494259,,ui,message,    googlecompute: 'C:\ProgramData\chocolatey\lib\webpicmd\tools\tools\chocolateyInstall.ps1'.  See log for details.  Chocolatey installed
1621494259,,ui,message,    googlecompute:  1/2 packages. 1 packages failed.  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).  Failures
1621494259,,ui,message,    googlecompute: - webpicmd (exited 404) - Error while running
1621494259,,ui,message,    googlecompute: 'C:\ProgramData\chocolatey\lib\webpicmd\tools\tools\chocolateyInstall.ps1'.  See log for details.
```