### PR TITLE
Bump VS2019Community installer to v16.11.4

### DIFF
--- a/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
+++ b/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
@@ -58,7 +58,7 @@ Configuration CircleMicrosoftTools {
         cChocoPackageInstaller visualStudio
         {
             Name      = "visualstudio2019community"
-            Version   = "16.3.6.0"
+            Version   = "16.11.4.0"
             Params    = "--allWorkloads --includeRecommended --no-update --includeOptional --passive --noUpdateInstaller --locale en-US"
             DependsOn = "[CircleChoco]choco"
         }
@@ -71,7 +71,7 @@ Configuration CircleMicrosoftTools {
         cChocoPackageInstaller visualstudiobuildtools
         {
             Name      = "visualstudio2019buildtools"
-            Version   = "16.3.6.0"
+            Version   = "16.11.4.0"
             DependsOn = "[CircleChoco]choco"
         }
         


### PR DESCRIPTION
The version we're using is from 2019. It's time.

We're also debugging a Windows build issue that may be related. This helps rule that out.