### PR TITLE
Update Az Cli Version

### DIFF
--- a/DSCResources/CircleCloudTools/CircleCloudTools.schema.psm1
+++ b/DSCResources/CircleCloudTools/CircleCloudTools.schema.psm1
@@ -14,7 +14,7 @@ Configuration CircleCloudTools {
     cChocoPackageInstaller azure-cli
     {
         Name      = "azure-cli"
-        Version   = "2.0.70"
+        Version   = "2.40.0"
         DependsOn = "[CircleChoco]choco"
     }
 


### PR DESCRIPTION
Az Cli version 2.0.70 is [old](https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#july-30-2019).